### PR TITLE
Question component Slide

### DIFF
--- a/src/components/common/Question/Question.tsx
+++ b/src/components/common/Question/Question.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+
+interface SlideProps {
+	title?: string;
+	question: string;
+	answers: string[];
+	feedback?: string;
+	onSlideAdvance?(): void;
+}
+
+
+
+export function QuestionSlide({ title, question, answers }: SlideProps) {
+	//initalizing the state
+	const [selectedAnswer, setSelectedAnswer] = useState<string>();
+
+	const handleAnswerClick = (answer:string) => {
+		setSelectedAnswer(answer);
+	};
+
+	return (
+		<div className='flex flex-col justify-center items-center h-screen w-screen bg-gray-100'>
+			<div className='flex flex-col justify-center items-center w-96 h-auto p-10 border-4 border-gray-300 bg-white rounded-lg shadow-lg'>
+				<div className='text-2xl font-bold mb-4'>{title}</div>
+				<div className='text-lg mb-6'>{question}</div>
+				<div className='w-full'>
+					{answers.map((answer, index) => (
+						<button
+							key={index}
+							onClick={() => handleAnswerClick(answer)}
+							className={`w-full py-2 my-2 text-center rounded-lg ${
+								selectedAnswer === answer
+									? 'bg-green-500 text-white'
+									: 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+							}`}
+						>
+							{answer}
+						</button>
+					))}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/common/Question/QuestionSlide.tsx
+++ b/src/components/common/Question/QuestionSlide.tsx
@@ -25,8 +25,11 @@ export function QuestionSlide({ questions, answers }: SlideProps) {
 	return (
 		<div className='flex flex-col justify-center items-center h-screen w-screen bg-gray-100'>
 			<div className='flex flex-col justify-center items-center w-96 h-auto p-10 border-4 border-gray-300 bg-white rounded-lg shadow-lg'>
-				<div className='text-2xl font-bold mb-4'>{currentQuestion}</div>
-				<div className='text-lg mb-6'>{questions[questionIndex]}</div>
+				<div className='text-2xl font-bold mb-4'>
+					{' '}
+					Question: {currentQuestion}
+				</div>
+
 				<div>
 					{/* legendary piece of code  */}
 					{answers[questionIndex].map((option, index) => {

--- a/src/components/common/Question/QuestionSlide.tsx
+++ b/src/components/common/Question/QuestionSlide.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { Button } from '../Button/Button';
+interface SlideProps {
+	questions: string[];
+	answers: string[][];
+	feedback?: string;
+	onSlideAdvance?(): void;
+}
+
+export function QuestionSlide({ questions, answers }: SlideProps) {
+	//initalizing the state
+	const [selectedAnswer, setSelectedAnswer] = useState<string>();
+	const [currentQuestion, setCurrentQuestion] = useState(1);
+
+	const [questionIndex, setQuestionIndex] = useState(0);
+
+	const handleAnswerClick = (answer: string) => {
+		setSelectedAnswer(answer);
+	};
+	const incrementQuestionHandler = () => {
+		setCurrentQuestion(currentQuestion + 1);
+		setQuestionIndex(questionIndex + 1);
+	};
+
+	return (
+		<div className='flex flex-col justify-center items-center h-screen w-screen bg-gray-100'>
+			<div className='flex flex-col justify-center items-center w-96 h-auto p-10 border-4 border-gray-300 bg-white rounded-lg shadow-lg'>
+				<div className='text-2xl font-bold mb-4'>{currentQuestion}</div>
+				<div className='text-lg mb-6'>{questions[questionIndex]}</div>
+				<div>
+					{/* legendary piece of code  */}
+					{answers[questionIndex].map((option, index) => {
+						return (
+							<button
+								key={index}
+								onClick={() => handleAnswerClick(option)}
+								className={`w-full py-2 my-2 text-center rounded-lg ${
+									selectedAnswer === option
+										? 'bg-green-500 text-white'
+										: 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+								}`}
+							>
+								{option}
+							</button>
+						);
+					})}
+				</div>
+			</div>
+			<Button name='Next' handler={incrementQuestionHandler} />
+		</div>
+	);
+}

--- a/src/components/common/Question/QuestionSlide.tsx
+++ b/src/components/common/Question/QuestionSlide.tsx
@@ -30,7 +30,7 @@ export function QuestionSlide({ questions, answers }: SlideProps) {
 					Question: {currentQuestion}
 				</div>
 
-				<div>
+				<div className='pb-4'>
 					{/* legendary piece of code  */}
 					{answers[questionIndex].map((option, index) => {
 						return (
@@ -48,8 +48,8 @@ export function QuestionSlide({ questions, answers }: SlideProps) {
 						);
 					})}
 				</div>
+				<Button name='Next' handler={incrementQuestionHandler} />
 			</div>
-			<Button name='Next' handler={incrementQuestionHandler} />
 		</div>
 	);
 }


### PR DESCRIPTION
Here is a question component slide

- you can click next and the next questions renders
<img width="553" alt="Screenshot 2024-05-29 at 17 36 59" src="https://github.com/fac29/P1DAAF-Frontend/assets/112947016/264712bf-c901-4a4c-8787-90e221f3cb0b">
<img width="411" alt="Screenshot 2024-05-29 at 17 37 08" src="https://github.com/fac29/P1DAAF-Frontend/assets/112947016/7bf609f0-7b41-44a8-9a9d-0e26f17eb353">



how to test

go to this file `/src/components/pages/QuestionBank/QuestionBank.tsx`


add these props


```
				questions={[
					'What is the capital city of France?',
					'What is the capital city of Japan?',
				]}
				answers={[['Paris', 'London', 'New York', 'Madrid'],['Mexico City', 'Beijing', 'Jaipur', 'Tokyo']]}
``` 




<img width="952" alt="Screenshot 2024-05-29 at 17 40 45" src="https://github.com/fac29/P1DAAF-Frontend/assets/112947016/0896fb8c-aacd-4b0a-940c-ecdb780d41ec">

Have Funnnnnnnn

<img src="https://media0.giphy.com/media/j3gsT2RsH9K0w/giphy.gif"/>
